### PR TITLE
PoseService 랜덤 포즈 추천 로직 수정

### DIFF
--- a/src/main/java/com/example/PixelPioneers/Service/PoseService.java
+++ b/src/main/java/com/example/PixelPioneers/Service/PoseService.java
@@ -15,10 +15,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Transactional
@@ -29,7 +26,8 @@ public class PoseService {
     private final User_AlbumJPARepository user_albumJPARepository;
     private final PoseJPARepository poseJPARepository;
 
-    private List<Integer> randomIndexList = new ArrayList<>();
+    private int index = 0;
+
 
     /**
      * 랜덤 포즈 조회
@@ -37,25 +35,37 @@ public class PoseService {
      */
     public PoseResponse.PoseDTO randomPoseDetailByPeopleCount(int peopleCount) {
         List<Pose> poseList = poseJPARepository.findByPeopleCountAndOpenAndPass(peopleCount, true, "ACCEPT");
+        List<Integer> randomIndexList = makeRandomIndexList(10, poseList.size());
 
-        if (randomIndexList.size() == 10) {
-            randomIndexList.clear();
+        if (index == 10 - 1) {
+            index = 0;
+            randomIndexList = makeRandomIndexList(10, poseList.size());
         }
 
-        Random random = new Random();
-        random.setSeed(System.currentTimeMillis());
-
-        int randomIndex;
-        while (true) {
-            randomIndex = random.nextInt(poseList.size());
-            if (!randomIndexList.contains(randomIndex)) {
-                randomIndexList.add(randomIndex);
-                break;
-            }
-        }
+        int randomIndex = randomIndexList.get(index++);
         Pose randomPose = poseList.get(randomIndex);
 
         return new PoseResponse.PoseDTO(randomPose);
+    }
+
+    private List<Integer> makeRandomIndexList(int size, int max) {
+        Random random = new Random();
+        random.setSeed(System.currentTimeMillis());
+
+        List<Integer> randomIndexList = new ArrayList<>(size);
+        Set<Integer> randomIndexSet = new HashSet<>(size);
+
+        while (true) {
+            int randomNum = random.nextInt(max);
+            if (randomIndexSet.contains(randomNum))
+                continue;
+            randomIndexList.add(randomNum);
+            randomIndexSet.add(randomNum);
+            if (randomIndexSet.size() == size)
+                break;
+        }
+
+        return randomIndexList;
     }
 
     /**

--- a/src/main/java/com/example/PixelPioneers/Service/PoseService.java
+++ b/src/main/java/com/example/PixelPioneers/Service/PoseService.java
@@ -1,11 +1,8 @@
 package com.example.PixelPioneers.Service;
 
-import com.example.PixelPioneers.DTO.AlbumResponse;
 import com.example.PixelPioneers.DTO.PoseResponse;
 import com.example.PixelPioneers.config.errors.exception.Exception404;
-import com.example.PixelPioneers.entity.Album;
 import com.example.PixelPioneers.entity.Pose;
-import com.example.PixelPioneers.repository.PhotoJPARepository;
 import com.example.PixelPioneers.repository.PoseJPARepository;
 import com.example.PixelPioneers.repository.User_AlbumJPARepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.PostConstruct;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -26,29 +24,47 @@ public class PoseService {
     private final User_AlbumJPARepository user_albumJPARepository;
     private final PoseJPARepository poseJPARepository;
 
-    private int index = 0;
+    private final int MAX_PEOPLE_COUNT = 5;
+    private final int DUPLICATION_LIMIT = 10;
 
+
+    private int[] indexes = new int[MAX_PEOPLE_COUNT];
+    private List<Integer>[] randomIndexLists = new List[10];
+    private List<Pose>[] poseLists = new List[MAX_PEOPLE_COUNT];
+
+    @PostConstruct
+    public void postConstructor() {
+        for (int i = 0; i < MAX_PEOPLE_COUNT; i++) {
+            int peopleCount = i + 1;
+            initHelper(peopleCount);
+        }
+    }
+
+    private void initHelper(int peopleCount) {
+        indexes[peopleCount - 1] = 0;
+        poseLists[peopleCount - 1] = poseJPARepository.findByPeopleCountAndOpenAndPass(peopleCount, true, "ACCEPT");
+        randomIndexLists[peopleCount - 1] = makeRandomIndexList(DUPLICATION_LIMIT, poseLists[peopleCount - 1].size());
+    }
 
     /**
      * 랜덤 포즈 조회
      * 인원 수에 따른 랜덤 포즈 개별 조회
+     * 10번의 요청 동안 중복되는 포즈 x
      */
     public PoseResponse.PoseDTO randomPoseDetailByPeopleCount(int peopleCount) {
-        List<Pose> poseList = poseJPARepository.findByPeopleCountAndOpenAndPass(peopleCount, true, "ACCEPT");
-        List<Integer> randomIndexList = makeRandomIndexList(10, poseList.size());
+        if (peopleCount > MAX_PEOPLE_COUNT) throw new Exception404("요청한 peopleCount를 갖는 포즈가 없습니다.");
 
-        if (index == 10 - 1) {
-            index = 0;
-            randomIndexList = makeRandomIndexList(10, poseList.size());
+        if (indexes[peopleCount - 1] == DUPLICATION_LIMIT - 1) {
+            initHelper(peopleCount);
         }
 
-        int randomIndex = randomIndexList.get(index++);
-        Pose randomPose = poseList.get(randomIndex);
+        int randomIndex = randomIndexLists[peopleCount - 1].get(indexes[peopleCount - 1]++);
+        Pose randomPose = poseLists[peopleCount - 1].get(randomIndex);
 
         return new PoseResponse.PoseDTO(randomPose);
     }
 
-    private List<Integer> makeRandomIndexList(int size, int max) {
+    private static List<Integer> makeRandomIndexList(int size, int max) {
         Random random = new Random();
         random.setSeed(System.currentTimeMillis());
 


### PR DESCRIPTION
기존의 랜덤 포즈 조회 로직을 수정하였습니다.
<br>

- 기존 로직에서는 randomIndexList에 randomIndex가 있는지 .contains로 매번 검사를 해주었는데, 이는 O(n)의 시간 복잡도를 갖기 때문에 비효율적입니다.
- 대신 HashSet을 활용하여 중복 체크 시간 복잡도를 O(1)로 개선하였습니다. (HashSet.contains()의 시간 복잡도는 O(1))
<br>

- 기존 로직에서는 randomIndexList을 초기화 할 때 크기를 지정하지 않았기 때문에, add()를 수행할 경우 크기를 늘리기 위해 내부적으로 리스트 전체를 복사하여 새로운 리스트를 만들 가능성이 있습니다.
- 대신 randomIndexList를 초기화 할 때 크기를 지정하여 이러한 가능성을 제거하였습니다.